### PR TITLE
Add support for Scala

### DIFF
--- a/dbcexplode.py
+++ b/dbcexplode.py
@@ -19,6 +19,7 @@ def getExtension(notebook, command):
     'python': 'py',
     'md': 'md',
     'sql': 'sql',
+    'scala': 'scala',
   }
   cmdstr = command['command']
   if len(cmdstr) == 0:
@@ -28,7 +29,7 @@ def getExtension(notebook, command):
   ext = extMap[prefix] if prefix in extMap else None
   
   if ext is None:
-    ext = extMap[notebook['language']]
+    ext = extMap.get(notebook['language'])
     
   return ext if ext is not None else '' 
   


### PR DESCRIPTION
`extMap` is missing Scala which is common in DBC files. It also throws the following exception if both the files and notebook have an unknown language.

```
Traceback (most recent call last):
  File "dbcexplode.py", line 123, in <module>
    main()
  File "dbcexplode.py", line 115, in main
    processzipfile(filepath)
  File "dbcexplode.py", line 96, in processzipfile
    processdir(destDir, deleteFileAfter=True)
  File "dbcexplode.py", line 86, in processdir
    processjsonfile(fullpath)
  File "dbcexplode.py", line 71, in processjsonfile
    ext = getExtension(notebook, command)
  File "dbcexplode.py", line 31, in getExtension
    ext = extMap[notebook['language']]
KeyError: u'scala'
```